### PR TITLE
ignore non-jest workspace roots

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -84,10 +84,13 @@ export default class JestTestAdapter implements TestAdapter {
       this.testsEmitter.fire({ type: "started" });
 
       const state = await this.projectManager.getTestState();
-      this.tree = state.suite;
-      const suite = mapWorkspaceRootToSuite(this.tree);
-
-      this.testsEmitter.fire({ suite, type: "finished" });
+      if (state) {
+        this.tree = state.suite;
+        const suite = mapWorkspaceRootToSuite(this.tree);
+        this.testsEmitter.fire({ suite, type: "finished" });
+      } else {
+        this.testsEmitter.fire({ type: "finished" });
+      }
     } catch (error) {
       this.log.error("Error loading tests", JSON.stringify(error));
       this.testsEmitter.fire({ type: "finished", errorMessage: JSON.stringify(error) });


### PR DESCRIPTION
I have a workspace with folders without tests:
![image](https://user-images.githubusercontent.com/2453277/79542181-12a38980-8083-11ea-9e3c-9ede91a59497.png)
...
and I always get errors:
![image](https://user-images.githubusercontent.com/2453277/79542254-3070ee80-8083-11ea-97e2-af79372d9748.png)

After this fix they're just ignored
![image](https://user-images.githubusercontent.com/2453277/79542414-7f1e8880-8083-11ea-9b39-c0d1aa414fab.png)


Not having tests in wiki sounds perfectly legit to me :)

