### PR TITLE
add workspace root to root label

### DIFF
--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -66,7 +66,7 @@ class ProjectManager {
 
     this.workspaceTestState = {
       id: "root",
-      label: `${this.workspace.name} (${this.repoParser.type})`,
+      label: `${this.workspace.name}`,
       projects: testStates.map(x => x.suite),
       type: "workspaceRootNode",
     };

--- a/src/ProjectManager.ts
+++ b/src/ProjectManager.ts
@@ -66,7 +66,7 @@ class ProjectManager {
 
     this.workspaceTestState = {
       id: "root",
-      label: this.repoParser.type,
+      label: `${this.workspace.name} (${this.repoParser.type})`,
       projects: testStates.map(x => x.suite),
       type: "workspaceRootNode",
     };


### PR DESCRIPTION
I found it confusing to have several roots with the same name:

![image](https://user-images.githubusercontent.com/2453277/79542254-3070ee80-8083-11ea-97e2-af79372d9748.png)

Like it much better with the workspace root added:
![image](https://user-images.githubusercontent.com/2453277/79543240-05879a00-8085-11ea-9a19-753a07ff125a.png)
Best regards
Marcello