### PR TITLE
retire tests on file change

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -223,7 +223,10 @@ export default class JestTestAdapter implements TestAdapter {
         case "projectAdded":
           this.retireTestFiles(event.addedProject.files.map(f => f.file));
           break;
-
+        case "projectTestsUpdated":
+        case "projectAppUpdated":
+          this.retireTestFiles([suite.id]); // more than necessary but works
+          break;
         case "projectRemoved":
           // Assume that if we are removing a project, then we don't need to invalidate anything.
           break;


### PR DESCRIPTION
Right now only does it if some re added/removed, not on file change.
One could argue it refreshes more than needed, but the incoming invalidated IDs are wrong (filename rather than project.filename)
Imho running the whole suite makes more sense anyway. God knows what test will break changing a file