### PR TITLE
Handle test file parsing errors

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "singleQuote": false,
   "bracketSpacing": true,
   "printWidth": 120,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "arrowParens": "avoid"
 }

--- a/src/TestParser.ts
+++ b/src/TestParser.ts
@@ -1,5 +1,11 @@
-import * as fs from "fs";
-import { IParseResults, JestSettings, parse } from "jest-editor-support";
+import fs from "fs";
+import {
+  IParseResults,
+  JestSettings,
+  parse as editorSupportParse,
+  ParsedNode,
+  ParsedNodeTypes,
+} from "jest-editor-support";
 import _ from "lodash";
 import * as mm from "micromatch";
 import * as path from "path";
@@ -12,121 +18,6 @@ import { cancellationTokenNone, Matcher } from "./types";
  * Only universally recognized patterns should be used here, such as node_modules.
  */
 const IGNORE_GLOBS = ["node_modules"];
-
-/**
- * Returns true if the specified path is a directory, false otherwise.
- * @param directory The full file system path to the check.
- */
-function checkIsDirectory(
-  directory: string,
-  cancellationToken: vscode.CancellationToken = cancellationTokenNone,
-): Promise<boolean> {
-  let reject: (reason?: any) => void;
-
-  const promise = new Promise<boolean>((resolve, xReject) => {
-    reject = xReject;
-
-    fs.stat(directory, (err, stats) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(stats.isDirectory());
-      }
-    });
-  });
-
-  cancellationToken.onCancellationRequested(() => reject("Cancellation requested."));
-
-  return promise;
-}
-
-/**
- * Creates a matcher function that returns true if a file should be explored for tests, false otherwise.
- * @param settings The Jest settings.
- */
-function createMatcher(settings: JestSettings): Matcher {
-  // TODO what to do if there is more than one config?...
-
-  if (settings?.configs?.length > 0 && settings.configs[0].testRegex?.length > 0) {
-    const regex = new RegExp(settings.configs[0].testRegex[0]);
-    return value => regex.test(value);
-  } else {
-    return value => mm.any(value, settings.configs[0].testMatch);
-  }
-}
-
-/**
- * Explores a directory recursively and returns the TestSuiteInfo representing the directory.
- * @param directory The full file system path to the directory.
- * @param matcher The matcher function to use to determine if a file includes tests.
- */
-async function exploreDirectory(
-  directory: string,
-  matcher: Matcher,
-  cancellationToken: vscode.CancellationToken = cancellationTokenNone,
-): Promise<IParseResults[]> {
-  const contents = await getDirectoryContents(directory, cancellationToken);
-  const files = await Promise.all(contents.map(x => evaluateFilePath(x, matcher, cancellationToken)));
-  return _.flatten(files);
-}
-
-/**
- * Evaluates a file path and returns the TestSuiteInfo representing it.
- * If the path is a directory, it will recursively explore it.
- * If the path is a file, it will parse the contents and search for test blocks.
- * If the directory or file did not include any tests, null will be returned.
- * @param filePath The file path to evaluate.
- * @param matcher The matcher function to use to determine if a file includes tests.
- */
-async function evaluateFilePath(
-  filePath: string,
-  matcher: Matcher,
-  cancellationToken: vscode.CancellationToken = cancellationTokenNone,
-): Promise<IParseResults[]> {
-  const isDirectory = await checkIsDirectory(filePath, cancellationToken);
-  if (isDirectory) {
-    return await exploreDirectory(filePath, matcher, cancellationToken);
-  } else if (matcher(filePath)) {
-    return [parse(filePath)];
-  } else {
-    return [];
-  }
-}
-
-/**
- * Retrieves the contents of a directory and outputs their absolute paths.
- * Includes both files and directories.
- * Excludes glob patterns included in IGNORE_GLOBS.
- * @param directory Returns an array of absolute paths representing the items within the directory.
- */
-function getDirectoryContents(
-  directory: string,
-  cancellationToken: vscode.CancellationToken = cancellationTokenNone,
-): Promise<string[]> {
-  let reject: (reason?: any) => void;
-
-  const promise = new Promise<string[]>((resolve, xReject) => {
-    reject = xReject;
-
-    fs.readdir(directory, (err, files) => {
-      if (err) {
-        reject(err);
-      } else {
-        const includedFiles = mm.not(files, IGNORE_GLOBS);
-        resolve(includedFiles.map(f => path.join(directory, f)));
-      }
-    });
-  });
-
-  cancellationToken.onCancellationRequested(() => reject("Cancellation requested."));
-  return promise;
-}
-
-// interface Cancellable {
-//   cancel: () => void;
-// }
-
-// interface CancellablePromise<T> extends PromiseLike<T>, Cancellable {}
 
 class TestParser {
   public constructor(
@@ -143,23 +34,156 @@ class TestParser {
     // TODO there is a Jest CLI option --listTests that will provide a list of test files that the current Jest config
     // resolves.  We should use this instead of trying to do the regex ourselves.
 
-    const parsedResults = await exploreDirectory(this.rootPath, matcher, cancellationToken);
+    const parsedResults = await this.exploreDirectory(this.rootPath, matcher, cancellationToken);
     this.log.info("Test load complete");
 
     return parsedResults;
   }
 
-  public parseFiles(files: string[], cancellationToken: vscode.CancellationToken = cancellationTokenNone): IParseResults[] {
+  public parseFiles(
+    files: string[],
+    cancellationToken: vscode.CancellationToken = cancellationTokenNone,
+  ): IParseResults[] {
     // TODO this method should potentially be async...
     const matcher = createMatcher(this.settings);
-    
-    return files.filter(matcher).map(f => {
+
+    return files.filter(matcher).map((f) => {
       if (cancellationToken.isCancellationRequested) {
         throw Error("Cancellation requested.");
       }
-      return parse(f);
+      return this.parse(f);
     });
   }
+
+  /**
+   * Evaluates a file path and returns the TestSuiteInfo representing it.
+   * If the path is a directory, it will recursively explore it.
+   * If the path is a file, it will parse the contents and search for test blocks.
+   * If the directory or file did not include any tests, null will be returned.
+   * @param filePath The file path to evaluate.
+   * @param matcher The matcher function to use to determine if a file includes tests.
+   */
+  private async evaluateFilePath(
+    filePath: string,
+    matcher: Matcher,
+    cancellationToken: vscode.CancellationToken = cancellationTokenNone,
+  ): Promise<IParseResults[]> {
+    const isDirectory = await this.checkIsDirectory(filePath, cancellationToken);
+    if (isDirectory) {
+      return await this.exploreDirectory(filePath, matcher, cancellationToken);
+    } else if (matcher(filePath)) {
+      return [this.parse(filePath)];
+    } else {
+      return [];
+    }
+  }
+
+  /**
+   * Returns true if the specified path is a directory, false otherwise.
+   * @param directory The full file system path to the check.
+   */
+  private checkIsDirectory(
+    directory: string,
+    cancellationToken: vscode.CancellationToken = cancellationTokenNone,
+  ): Promise<boolean> {
+    let reject: (reason?: any) => void;
+
+    const promise = new Promise<boolean>((resolve, xReject) => {
+      reject = xReject;
+
+      fs.stat(directory, (err, stats) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(stats.isDirectory());
+        }
+      });
+    });
+
+    cancellationToken.onCancellationRequested(() => reject("Cancellation requested."));
+
+    return promise;
+  }
+
+  /**
+   * Explores a directory recursively and returns the TestSuiteInfo representing the directory.
+   * @param directory The full file system path to the directory.
+   * @param matcher The matcher function to use to determine if a file includes tests.
+   */
+  private async exploreDirectory(
+    directory: string,
+    matcher: Matcher,
+    cancellationToken: vscode.CancellationToken = cancellationTokenNone,
+  ): Promise<IParseResults[]> {
+    const contents = await this.getDirectoryContents(directory, cancellationToken);
+    const files = await Promise.all(contents.map((x) => this.evaluateFilePath(x, matcher, cancellationToken)));
+    return _.flatten(files);
+  }
+
+  /**
+   * Parses the given test file using `jest-editor-support`'s `parse` method.  If there are parsing errors, will return
+   * a placeholder result with empty tests.  In future, this will return an error object to display the results to the
+   * user.
+   * @param file the path of the file to parse.
+   */
+  private parse(file: string): IParseResults {
+    try {
+      return editorSupportParse(file);
+    } catch (error) {
+      this.log.error(error);
+      return {
+        describeBlocks: [],
+        expects: [],
+        file,
+        itBlocks: [],
+        root: new ParsedNode(ParsedNodeTypes.root, file),
+      };
+    }
+  }
+
+  /**
+   * Retrieves the contents of a directory and outputs their absolute paths.
+   * Includes both files and directories.
+   * Excludes glob patterns included in IGNORE_GLOBS.
+   * @param directory Returns an array of absolute paths representing the items within the directory.
+   */
+  private getDirectoryContents(
+    directory: string,
+    cancellationToken: vscode.CancellationToken = cancellationTokenNone,
+  ): Promise<string[]> {
+    let reject: (reason?: any) => void;
+
+    const promise = new Promise<string[]>((resolve, xReject) => {
+      reject = xReject;
+
+      fs.readdir(directory, (err, files) => {
+        if (err) {
+          reject(err);
+        } else {
+          const includedFiles = mm.not(files, IGNORE_GLOBS);
+          resolve(includedFiles.map((f) => path.join(directory, f)));
+        }
+      });
+    });
+
+    cancellationToken.onCancellationRequested(() => reject("Cancellation requested."));
+    return promise;
+  }
 }
+
+/**
+ * Creates a matcher function that returns true if a file should be explored for tests, false otherwise.
+ * @param settings The Jest settings.
+ */
+const createMatcher = (settings: JestSettings): Matcher => {
+  // TODO what to do if there is more than one config?...
+
+  if (settings?.configs?.length > 0 && settings.configs[0].testRegex?.length > 0) {
+    const regex = new RegExp(settings.configs[0].testRegex[0]);
+    return (value) => regex.test(value);
+  } else {
+    return (value) => mm.any(value, settings.configs[0].testMatch);
+  }
+};
 
 export { TestParser as default, createMatcher };

--- a/src/helpers/emitTestCompleteRootNode.ts
+++ b/src/helpers/emitTestCompleteRootNode.ts
@@ -1,5 +1,13 @@
 import { TestEvent, TestRunFinishedEvent, TestRunStartedEvent, TestSuiteEvent } from "vscode-test-adapter-api";
-import { DescribeNode, FileNode, FolderNode, ProjectRootNode, TestNode, WorkspaceRootNode } from "./tree";
+import {
+  DescribeNode,
+  FileNode,
+  FileWithParseErrorNode,
+  FolderNode,
+  ProjectRootNode,
+  TestNode,
+  WorkspaceRootNode,
+} from "./tree";
 
 const emitTestCompleteRootNode = (
   root: WorkspaceRootNode | ProjectRootNode,
@@ -55,22 +63,31 @@ const emitTestCompleteFolder = (
     suite: folder.id,
     type: "suite",
   });
+
   folder.folders.forEach(f => emitTestCompleteFolder(f, testEvents, eventEmitter));
   folder.files.forEach(f => emitTestCompleteFile(f, testEvents, eventEmitter));
 };
 
 const emitTestCompleteFile = (
-  file: FileNode,
+  file: FileNode | FileWithParseErrorNode,
   testEvents: TestEvent[],
   eventEmitter: (data: TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent) => void,
 ) => {
-  eventEmitter({
-    state: "completed",
-    suite: file.id,
-    type: "suite",
-  });
-  file.describeBlocks.forEach(d => emitTestCompleteDescribe(d, testEvents, eventEmitter));
-  file.tests.forEach(t => emitTestCompleteTest(t, testEvents, eventEmitter));
+  switch (file.type) {
+    case "file":
+      eventEmitter({
+        state: "completed",
+        suite: file.id,
+        type: "suite",
+      });
+      file.describeBlocks.forEach(d => emitTestCompleteDescribe(d, testEvents, eventEmitter));
+      file.tests.forEach(t => emitTestCompleteTest(t, testEvents, eventEmitter));
+      break;
+
+    case "fileWithParseError":
+      // TODO support is needed in Host to support suites that have errors.
+      break;
+  }
 };
 
 const emitTestCompleteDescribe = (
@@ -154,7 +171,7 @@ const emitTestRunningFolder = (
 };
 
 const emitTestRunningFile = (
-  file: FileNode,
+  file: FileNode | FileWithParseErrorNode,
   eventEmitter: (data: TestRunStartedEvent | TestRunFinishedEvent | TestSuiteEvent | TestEvent) => void,
 ) => {
   eventEmitter({
@@ -162,8 +179,18 @@ const emitTestRunningFile = (
     suite: file.id,
     type: "suite",
   });
-  file.describeBlocks.forEach(d => emitTestRunningDescribe(d, eventEmitter));
-  file.tests.forEach(t => emitTestRunningTest(t, eventEmitter));
+
+  switch (file.type) {
+    case "file":
+      file.describeBlocks.forEach(d => emitTestRunningDescribe(d, eventEmitter));
+      file.tests.forEach(t => emitTestRunningTest(t, eventEmitter));
+      break;
+
+    case "fileWithParseError":
+      // Currently we do not emit anything to indicate that we are running the files with parse errors.  This may not
+      // be the correct choice...
+      break;
+  }
 };
 
 const emitTestRunningDescribe = (

--- a/src/helpers/mapTreeToSuite.ts
+++ b/src/helpers/mapTreeToSuite.ts
@@ -2,12 +2,20 @@ import _ from "lodash";
 import vscode from "vscode";
 import { TestInfo, TestSuiteInfo } from "vscode-test-adapter-api";
 import { EXTENSION_CONFIGURATION_NAME } from "../constants";
-import { DescribeNode, FileNode, FolderNode, ProjectRootNode, TestNode, WorkspaceRootNode } from "./tree";
+import {
+  DescribeNode,
+  FileNode,
+  FileWithParseErrorNode,
+  FolderNode,
+  ProjectRootNode,
+  TestNode,
+  WorkspaceRootNode,
+} from "./tree";
 
 const mapWorkspaceRootToSuite = (rootNode: WorkspaceRootNode): TestSuiteInfo | undefined => {
   let projects: ProjectRootNode[];
   if (shouldHideEmptyProjects()) {
-    projects = rootNode.projects.filter((p) => p.files.length > 0 || _.some(p.folders, (f) => folderHasFiles(f)));
+    projects = rootNode.projects.filter(p => p.files.length > 0 || _.some(p.folders, f => folderHasFiles(f)));
   } else {
     projects = rootNode.projects;
   }
@@ -35,7 +43,7 @@ const shouldHideEmptyProjects = () =>
   vscode.workspace.getConfiguration(EXTENSION_CONFIGURATION_NAME, null).get<boolean>("hideEmptyProjects") ?? true;
 
 const folderHasFiles = (folder: FolderNode): boolean =>
-  folder.files.length > 0 || _.some(folder.folders, (f) => folderHasFiles(f));
+  folder.files.length > 0 || _.some(folder.folders, f => folderHasFiles(f));
 
 const mapProjectRootNodeToSuite = ({ label, id, files, folders }: ProjectRootNode): TestSuiteInfo => ({
   children: folders.map(mapFolderNodeToTestSuite).concat(files.map(mapFileNodeToTestSuite)),
@@ -51,18 +59,36 @@ const mapFolderNodeToTestSuite = (folder: FolderNode): TestSuiteInfo => ({
   type: "suite",
 });
 
-const mapFileNodeToTestSuite = (file: FileNode): TestSuiteInfo => ({
-  children: file.describeBlocks
-    .map((d) => mapDescribeBlockToTestSuite(d) as TestSuiteInfo | TestInfo)
-    .concat(file.tests.map(mapTestToTestInfo)),
-  id: file.id,
-  label: file.label,
-  type: "suite",
-});
+const mapFileNodeToTestSuite = (file: FileNode | FileWithParseErrorNode): TestSuiteInfo => {
+  const common: Pick<TestSuiteInfo, "file" | "id" | "label" | "type"> = {
+    file: file.file,
+    id: file.id,
+    label: file.label,
+    type: "suite",
+  };
+
+  switch (file.type) {
+    case "file":
+      return {
+        ...common,
+        children: file.describeBlocks
+          .map(d => mapDescribeBlockToTestSuite(d) as TestSuiteInfo | TestInfo)
+          .concat(file.tests.map(mapTestToTestInfo)),
+      };
+
+    case "fileWithParseError":
+      return {
+        ...common,
+        children: [],
+        description: "(parse error)",
+        tooltip: "Error parsing test file.  This may not be an issue with your code, but check the extension logs for details."
+      };
+  }
+};
 
 const mapDescribeBlockToTestSuite = (describe: DescribeNode): TestSuiteInfo => ({
   children: describe.describeBlocks
-    .map((d) => mapDescribeBlockToTestSuite(d) as TestInfo | TestSuiteInfo)
+    .map(d => mapDescribeBlockToTestSuite(d) as TestInfo | TestSuiteInfo)
     .concat(describe.tests.map(mapTestToTestInfo)),
   file: describe.file,
   id: describe.id,

--- a/src/helpers/tree.ts
+++ b/src/helpers/tree.ts
@@ -3,10 +3,17 @@ interface NodeBase {
   label: string;
 }
 
-export type Node = WorkspaceRootNode | ProjectRootNode | FolderNode | FileNode | DescribeNode | TestNode;
+export type Node =
+  | WorkspaceRootNode
+  | ProjectRootNode
+  | FolderNode
+  | FileNode
+  | FileWithParseErrorNode
+  | DescribeNode
+  | TestNode;
 
 export interface WorkspaceRootNode extends NodeBase {
-  id: "root",
+  id: "root";
   type: "workspaceRootNode";
   projects: ProjectRootNode[];
 }
@@ -14,7 +21,7 @@ export interface WorkspaceRootNode extends NodeBase {
 export interface ProjectRootNode extends NodeBase {
   type: "projectRootNode";
   folders: FolderNode[];
-  files: FileNode[];
+  files: Array<FileNode | FileWithParseErrorNode>;
   rootPath: string;
   configPath: string;
 }
@@ -22,7 +29,7 @@ export interface ProjectRootNode extends NodeBase {
 export interface FolderNode extends NodeBase {
   type: "folder";
   folders: FolderNode[];
-  files: FileNode[];
+  files: Array<FileNode | FileWithParseErrorNode>;
 }
 
 export interface FileNode extends NodeBase {
@@ -31,6 +38,12 @@ export interface FileNode extends NodeBase {
   tests: TestNode[];
   file: string;
   line: number;
+}
+
+export interface FileWithParseErrorNode extends NodeBase {
+  type: "fileWithParseError";
+  file: string;
+  error: string;
 }
 
 export interface DescribeNode extends NodeBase {
@@ -66,9 +79,9 @@ export const createWorkspaceRootNode = (): WorkspaceRootNode => {
     id: "root",
     label: "workspaceRootNode",
     projects: [],
-    type: "workspaceRootNode"
-  }
-}
+    type: "workspaceRootNode",
+  };
+};
 
 export const createProjectNode = (id: string, label: string, rootPath: string, configPath: string): ProjectRootNode => {
   return {
@@ -79,8 +92,8 @@ export const createProjectNode = (id: string, label: string, rootPath: string, c
     label,
     rootPath,
     type: "projectRootNode",
-  }
-}
+  };
+};
 
 export const createFolderNode = (id: string, label: string): FolderNode => ({
   files: [],
@@ -98,6 +111,19 @@ export const createFileNode = (id: string, label: string, file: string): FileNod
   label,
   tests: [],
   type: "file",
+});
+
+export const createFileWithParseErrorNode = (
+  id: string,
+  label: string,
+  file: string,
+  error: string,
+): FileWithParseErrorNode => ({
+  error,
+  file,
+  id,
+  label,
+  type: "fileWithParseError",
 });
 
 export const createDescribeNode = (id: string, label: string, file: string, line: number): DescribeNode => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import { JestTotalResults, TestReconciler } from "jest-editor-support";
+import { IParseResults, JestTotalResults, TestReconciler } from "jest-editor-support";
 import * as vscode from "vscode";
-import { WorkspaceRootNode, ProjectRootNode } from "./helpers/tree";
+import { ProjectRootNode, WorkspaceRootNode } from "./helpers/tree";
 
 export interface IJestResponse {
   results: JestTotalResults;
@@ -58,7 +58,7 @@ export type ProjectsChangedEvent =
   | {
       type: "projectTestsUpdated";
       suite: WorkspaceRootNode;
-      testEvent: ProjectTestsChangedEvent
+      testEvent: ProjectTestsChangedEvent;
     };
 
 export interface IDisposable {
@@ -66,3 +66,11 @@ export interface IDisposable {
 }
 
 export const cancellationTokenNone: vscode.CancellationToken = new vscode.CancellationTokenSource().token;
+
+export type TestFileParseResult = (IParseResults & { outcome: "success" }) | TestFileParseFailure;
+
+export interface TestFileParseFailure {
+  outcome: "failure";
+  file: string;
+  error: string;
+}


### PR DESCRIPTION
Sometimes we get parsing errors of test files.  This can be due to bad syntax but also the parser we use does have some issues.  This catches those errors and displays this information back to the user.

Mostly fixes the issues in #45.  The only outstanding issue is that it would be nice to show an error icon and message to the user similar to when there are failing tests.  The problem is that test "suites" cannot display this kind of error, only "tests".  So will raise this as an enhancement with the host adapter repo.