### PR TITLE
Fix #73 - Run individual globalSetup scripts of individual projects

### DIFF
--- a/src/JestSettings/index.ts
+++ b/src/JestSettings/index.ts
@@ -23,12 +23,8 @@ const convertToWorkspace = (projectConfig: ProjectConfig): ProjectWorkspace => {
     // jest config file exists.
     // quote the config file in case there is space chars.
     pathToConfig = `"${projectConfig.jestConfig}"`;
-    // the `--projects` command is kind of a workaround for setting the cwd to a directory other than the project root.
-    jestCommand = `${jestCommand} --projects "${projectConfig.jestConfig}"`;
   } else {
     // no jest config file.
-    // we don't add a `--projects` option since we are defaulting to the project root dir as the execution folder.
-
     // set pathToConfig to undefined.  This is a type error that should be fixed in jest-editor-support.
     pathToConfig = (undefined as unknown) as string;
   }

--- a/src/TestParser.ts
+++ b/src/TestParser.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { Log } from "vscode-test-adapter-util";
 import { cancellationTokenNone, Matcher, TestFileParseResult } from "./types";
-import { convertErrorToString } from './utils';
+import { convertErrorToString } from "./utils";
 
 /**
  * Glob patterns to globally ignore when searching for tests.
@@ -172,14 +172,17 @@ class TestParser {
  * @param settings The Jest settings.
  */
 const createMatcher = (settings: JestSettings): Matcher => {
-  // TODO what to do if there is more than one config?...
-
-  if (settings?.configs?.length > 0 && settings.configs[0].testRegex?.length > 0) {
-    const regex = new RegExp(settings.configs[0].testRegex[0], process.platform === "win32" ? "i" : undefined);
-    return value => regex.test(value);
-  } else {
-    return value => mm.any(value, settings.configs[0].testMatch, { nocase: process.platform === "win32" });
-  }
+  return value => {
+    // Check whether the value matches any config
+    return settings.configs.some(config => {
+      if (config.testRegex?.length) {
+        const regex = new RegExp(config.testRegex[0], process.platform === "win32" ? "i" : undefined);
+        return regex.test(value);
+      } else {
+        return mm.any(value, config.testMatch, { nocase: process.platform === "win32" });
+      }
+    });
+  };
 };
 
 export { TestParser as default, createMatcher };


### PR DESCRIPTION
This pull request fixed the issue I raised earlier:
[Regression] Project specific setup files not run when running tests #73

Jest configs can have multiple project entries with specific configuration like `globalSetup` scripts that should only be executed. if any of the tests of the project is run. Before this change, jest was run with the `-- projects <jestConfigPath>` command, which stopped jest from executing the `globalSetup` scripts by ignoring the project specific config for test runs. This bug is fixed by removing the the `--projects <jestConfigPath>` argument from running jest.

Removing this argument however surfaces a different issue, where tests are not detected properly when multiple project configurations are defined. The applied fix here is to adjust the `createMatcher` function to dynamically match a value against all configurations instead of only the first project configuration which has been hardcoded.

I would be open to adjust the change if there was another reason why jest should have been called with the `--projects` flag. Let me know if you have any comments or feedback, I tested it with multiple projects and it worked correctly and fixed the issues for me.