### PR TITLE
Fix #79 | Add "Flatten Tests in Explorer" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,13 @@
           "type": "boolean",
           "default": true
         },
+        "jestTestExplorer.flattenExplorer": {
+          "description": "When true, tests in the Test Explorer will be grouped only by `describe` labels instead of file/folder structure.",
+          "scope": "resource",
+          "title": "Flatten Tests in Explorer",
+          "type": "boolean",
+          "default": false
+        },
         "jestTestExplorer.featureToggles": {
           "description": "A list of feature toggles to enable experimental features.",
           "scope": "window",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -234,7 +234,14 @@ export default class JestTestAdapter implements TestAdapter {
       this.testsEmitter.fire({ type: "started" });
 
       this.tree = event.suite;
-      const suite = mapWorkspaceRootToSuite(this.tree);
+
+      const flattenExplorer = vscode.workspace
+        .getConfiguration(EXTENSION_CONFIGURATION_NAME, null)
+        .get<boolean>("flattenExplorer", false);
+
+      const suite = flattenExplorer
+        ? flatMapWorkspaceRootToSuite(this.tree)
+        : mapWorkspaceRootToSuite(this.tree);
 
       switch (event.type) {
         case "projectAdded":

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -284,7 +284,7 @@ export default class JestTestAdapter implements TestAdapter {
   }
 
   private logSuite(suiteOrTest?: TestSuiteInfo|TestInfo, depth: number = 0): void {
-    if (suiteOrTest == null) { return; }
+    if (_.isNil(suiteOrTest)) { return; }
 
     const indent = (inDepth: number): string => Array(inDepth).fill("  ").join("");
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -279,20 +279,14 @@ export default class JestTestAdapter implements TestAdapter {
   private logSuite(suiteOrTest?: TestSuiteInfo|TestInfo, depth: number = 0): void {
     if (suiteOrTest == null) { return; }
 
-    const indent = (inDepth: number): string => {
-      let spaces = "";
-      for (let i = 0; i < inDepth; i++) {
-        spaces += "  ";
-      }
-      return spaces;
-    };
+    const indent = (inDepth: number): string => Array(inDepth).fill("  ").join("");
 
     if (suiteOrTest.label) {
       this.log.info(`${indent(depth)}${suiteOrTest.label} (${suiteOrTest.type})`);
     }
 
     const suite = suiteOrTest as TestSuiteInfo;
-    if (suite.children) {
+    if (suite.children?.length > 0) {
       for (const child of suite.children) {
         this.logSuite(child, depth + 1);
       }

--- a/src/helpers/mapTreeToSuite.ts
+++ b/src/helpers/mapTreeToSuite.ts
@@ -47,9 +47,14 @@ const flatMapWorkspaceRootToSuite = ({ projects, id, label }: WorkspaceRootNode)
   }
 
   const suite = projects.reduce<TestSuiteInfo>((results, project) => {
+    // Get an array of only the describe blocks in the current project.
     const describeBlocks = findDescribeBlocksInNode(project);
-    const existingChildren = results.children;
-    const children = existingChildren.concat(describeBlocks.map(mapDescribeBlockToTestSuite));
+
+    // Map the describe blocks to a tree of suites, nested suites, and tests.
+    const currentChildren = describeBlocks.map(mapDescribeBlockToTestSuite);
+
+    // Merge this project's suites into the results.
+    const children = results.children.concat(currentChildren);
 
     return { ...results, children };
   }, {
@@ -58,6 +63,11 @@ const flatMapWorkspaceRootToSuite = ({ projects, id, label }: WorkspaceRootNode)
     label,
     type: "suite",
   });
+
+  // If the final children array is empty, return undefined to prevent the empty project from appearing in the list.
+  if (!suite.children.length) {
+    return undefined;
+  }
 
   return suite;
 };

--- a/src/helpers/mapTreeToSuite.ts
+++ b/src/helpers/mapTreeToSuite.ts
@@ -65,7 +65,7 @@ const flatMapWorkspaceRootToSuite = ({ projects, id, label }: WorkspaceRootNode)
   });
 
   // If the final children array is empty, return undefined to prevent the empty project from appearing in the list.
-  if (!suite.children.length) {
+  if (suite.children.length === 0) {
     return undefined;
   }
 

--- a/src/helpers/mapTreeToSuite.ts
+++ b/src/helpers/mapTreeToSuite.ts
@@ -48,11 +48,10 @@ const flatMapWorkspaceRootToSuite = ({ projects, id, label }: WorkspaceRootNode)
 
   const suite = projects.reduce<TestSuiteInfo>((results, project) => {
     const describeBlocks = findDescribeBlocksInNode(project);
+    const existingChildren = results.children;
+    const children = existingChildren.concat(describeBlocks.map(mapDescribeBlockToTestSuite));
 
-    return {
-      ...results,
-      children: describeBlocks.map(mapDescribeBlockToTestSuite),
-    }
+    return { ...results, children };
   }, {
     children: [],
     id,

--- a/src/helpers/tree.ts
+++ b/src/helpers/tree.ts
@@ -79,6 +79,14 @@ export interface NodeVisitor {
   visitTestNode: (test: TestNode) => void;
 }
 
+export const isProjectRootNode = (node: { type: string }): node is ProjectRootNode => {
+  return node.type === "projectRootNode";
+}
+
+export const isFolderNode = (node: { type: string }): node is FolderNode => {
+  return node.type === "folder";
+}
+
 export const createWorkspaceRootNode = (): WorkspaceRootNode => {
   return {
     id: "root",


### PR DESCRIPTION
This PR addresses issue #79 by adding a new option, "Flatten Tests in Explorer", which eliminates file/folder names from the list of tests in the Test Explorer UI, showing instead a flat list of test suites, with child suites and tests nested underneath those.

### Before:
![jest-test-explorer--expanded](https://user-images.githubusercontent.com/13191586/89723828-5bcc7000-d9c9-11ea-89d0-01722440ab9f.png)

### After:
![jest-test-explorer--flattened](https://user-images.githubusercontent.com/13191586/89723830-5ec76080-d9c9-11ea-9d56-a878ef282f8e.png)

There's still some work to be done here — ironically, I haven't added any tests yet to cover this. :P I'm brand new to Jest (and testing in general if I'm being honest), so I would appreciate some guidance on how I might go about designing the test cases. Would also appreciate any other feedback in the meantime.