### PR TITLE
Support workspaces

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -150,9 +150,12 @@ export default class JestTestAdapter implements TestAdapter {
       cwd: "${workspaceFolder}",
       internalConsoleOptions: "neverOpen",
       name: "vscode-jest-test-adapter",
-      program: "${workspaceFolder}/node_modules/jest/bin/jest",
       request: "launch",
       type: "node",
+      runtimeExecutable: "${workspaceFolder}/node_modules/.bin/jest",
+      windows: {
+        runtimeExecutable: "${workspaceFolder}/node_modules/.bin/jest.cmd"
+      },
     };
 
     await vscode.debug.startDebugging(this.workspace, debugConfiguration);


### PR DESCRIPTION
Improves https://github.com/kavod-io/vscode-jest-test-adapter/issues/72

While not perfect (ideally would not need to specify jest) it does make this project 100% functional in yarn workspaces

Improved support for workspaces.  By changing the debug target from js script to launcher in .bin directory, we rely on the installed location of jest.

Note: workspace users still need to list jest as a devDependency in package.json