### PR TITLE
make tsconfig optional for Nx

### DIFF
--- a/src/repo/NxdevAngular.ts
+++ b/src/repo/NxdevAngular.ts
@@ -9,7 +9,7 @@ interface NxAngular {
       builder: string;
       options: {
         jestConfig: string;
-        tsConfig: string;
+        tsConfig?: string;
         setupFile?: string;
       };
     };
@@ -39,7 +39,7 @@ class NxdevAngular extends NxdevBase<NxAngular> implements RepoParser {
       projectName,
       rootPath: path.resolve(this.workspaceRoot, path.dirname(options.jestConfig)),
       setupFile: options.setupFile && path.resolve(this.workspaceRoot, options.setupFile),
-      tsConfig: path.resolve(this.workspaceRoot, options.tsConfig),
+      tsConfig: options.tsConfig && path.resolve(this.workspaceRoot, options.tsConfig),
     };
   };
 }

--- a/src/repo/NxdevReact.ts
+++ b/src/repo/NxdevReact.ts
@@ -9,7 +9,7 @@ interface NxReact {
       builder: string;
       options: {
         jestConfig: string;
-        tsConfig: string;
+        tsConfig?: string;
         setupFile?: string;
       };
     };
@@ -39,7 +39,7 @@ class NxdevReact extends NxdevBase<NxReact> implements RepoParser {
       projectName,
       rootPath: path.resolve(this.workspaceRoot, path.dirname(options.jestConfig)),
       setupFile: options.setupFile && path.resolve(this.workspaceRoot, options.setupFile),
-      tsConfig: path.resolve(this.workspaceRoot, options.tsConfig),
+      tsConfig: options.tsConfig && path.resolve(this.workspaceRoot, options.tsConfig),
     };
   };
 }


### PR DESCRIPTION
Hey there!

I'm one of the core maintainers for Nx, who specifically maintains Jest (and Node), and for some reason I just discovered this extension now! 😮 

Anyway, thanks for your support for Nx workspaces! It's really awesome!

I'm creating this PR because in an upcoming version of Nx, we're going to be removing the `tsconfig` option in the workspace.json. Without the property, this extension kinda breaks 😞 

I'm just making this optional here.
