### PR TITLE
Fix issues preventing execution of describe blocks

### DIFF
--- a/src/helpers/__tests__/idMaps.test.ts
+++ b/src/helpers/__tests__/idMaps.test.ts
@@ -15,7 +15,7 @@ describe('mapStringToId', () => {
     });
   });
 
-  it('parses mutliple levels of describes', () => {
+  it('parses multiple levels of describes', () => {
     const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${DESCRIBE_ID_SEPARATOR}someDescribe1${DESCRIBE_ID_SEPARATOR}someDescribe2${DESCRIBE_ID_SEPARATOR}someDescribe3${TEST_ID_SEPARATOR}someTest`;
 
     const testId = mapStringToId(testString);
@@ -41,7 +41,7 @@ describe('mapStringToId', () => {
     });
   });
 
-  it('parses mutliple levels of describes when no test is present', () => {
+  it('parses multiple levels of describes when no test is present', () => {
     const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${DESCRIBE_ID_SEPARATOR}someDescribe1${DESCRIBE_ID_SEPARATOR}someDescribe2${DESCRIBE_ID_SEPARATOR}someDescribe3`;
 
     const testId = mapStringToId(testString);

--- a/src/helpers/__tests__/idMaps.test.ts
+++ b/src/helpers/__tests__/idMaps.test.ts
@@ -41,6 +41,19 @@ describe('mapStringToId', () => {
     });
   });
 
+  it('parses test when no describe is present', () => {
+    const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${TEST_ID_SEPARATOR}someTest`;
+
+    const testId = mapStringToId(testString);
+
+    expect(testId).toEqual({
+      projectId: 'someProject',
+      fileName: 'someFile',
+      describeIds: undefined,
+      testId: 'someTest'
+    });
+  });
+
   it('parses multiple levels of describes when no test is present', () => {
     const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${DESCRIBE_ID_SEPARATOR}someDescribe1${DESCRIBE_ID_SEPARATOR}someDescribe2${DESCRIBE_ID_SEPARATOR}someDescribe3`;
 

--- a/src/helpers/__tests__/idMaps.test.ts
+++ b/src/helpers/__tests__/idMaps.test.ts
@@ -1,0 +1,82 @@
+import { mapStringToId } from '../idMaps';
+import { DESCRIBE_ID_SEPARATOR, PROJECT_ID_SEPARATOR, TEST_ID_SEPARATOR } from "../../constants";
+
+describe('mapStringToId', () => {
+  it('parses project, file, describe, and test when all are present', () => {
+    const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${DESCRIBE_ID_SEPARATOR}someDescribe${TEST_ID_SEPARATOR}someTest`;
+
+    const testId = mapStringToId(testString);
+
+    expect(testId).toEqual({
+      projectId: 'someProject',
+      fileName: 'someFile',
+      describeIds: ['someDescribe'],
+      testId: 'someTest'
+    });
+  });
+
+  it('parses mutliple levels of describes', () => {
+    const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${DESCRIBE_ID_SEPARATOR}someDescribe1${DESCRIBE_ID_SEPARATOR}someDescribe2${DESCRIBE_ID_SEPARATOR}someDescribe3${TEST_ID_SEPARATOR}someTest`;
+
+    const testId = mapStringToId(testString);
+
+    expect(testId).toEqual({
+      projectId: 'someProject',
+      fileName: 'someFile',
+      describeIds: ['someDescribe1', 'someDescribe2', 'someDescribe3'],
+      testId: 'someTest'
+    });
+  });
+
+  it('parses describe when no test is present', () => {
+    const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${DESCRIBE_ID_SEPARATOR}someDescribe`;
+
+    const testId = mapStringToId(testString);
+
+    expect(testId).toEqual({
+      projectId: 'someProject',
+      fileName: 'someFile',
+      describeIds: ['someDescribe'],
+      testId: undefined
+    });
+  });
+
+  it('parses mutliple levels of describes when no test is present', () => {
+    const testString = `someProject${PROJECT_ID_SEPARATOR}someFile${DESCRIBE_ID_SEPARATOR}someDescribe1${DESCRIBE_ID_SEPARATOR}someDescribe2${DESCRIBE_ID_SEPARATOR}someDescribe3`;
+
+    const testId = mapStringToId(testString);
+
+    expect(testId).toEqual({
+      projectId: 'someProject',
+      fileName: 'someFile',
+      describeIds: ['someDescribe1', 'someDescribe2', 'someDescribe3'],
+      testId: undefined
+    });
+  });
+
+  it('parses project and file when no describe or test are present', () => {
+    const testString = `someProject${PROJECT_ID_SEPARATOR}someFile`;
+
+    const testId = mapStringToId(testString);
+
+    expect(testId).toEqual({
+      projectId: 'someProject',
+      fileName: 'someFile',
+      describeIds: undefined,
+      testId: undefined
+    });
+  });
+
+  it('parses project when no separators are present', () => {
+    const testString = `someProject`;
+
+    const testId = mapStringToId(testString);
+
+    expect(testId).toEqual({
+      projectId: 'someProject',
+      fileName: undefined,
+      describeIds: undefined,
+      testId: undefined
+    });
+  });
+});

--- a/src/helpers/filterTree.ts
+++ b/src/helpers/filterTree.ts
@@ -97,7 +97,11 @@ const filterDescribeBlocks = (describeBlocks: DescribeNode[], testNames: string[
       if (testNames.some(t => t === f.id)) {
         return f;
       }
-      return { ...f, tests: filterTests(f.tests, testNames) };
+      return {
+        ...f,
+        describeBlocks: filterDescribeBlocks(f.describeBlocks, testNames),
+        tests: filterTests(f.tests, testNames)
+      };
     });
 };
 

--- a/src/helpers/filterTree.ts
+++ b/src/helpers/filterTree.ts
@@ -7,8 +7,6 @@ import {
   TestNode,
   WorkspaceRootNode,
 } from "./tree";
-import { mapTestIdToTestNamePattern } from "./mapTestIdsToTestFilter";
-import { mapStringToId } from "./idMaps";
 
 function filterTree(tree: WorkspaceRootNode, testNames: string[]): WorkspaceRootNode;
 function filterTree(tree: ProjectRootNode, testNames: string[]): ProjectRootNode;

--- a/src/helpers/idMaps.ts
+++ b/src/helpers/idMaps.ts
@@ -26,15 +26,21 @@ const mapIdToString = (id: Id): string => {
 };
 
 const mapStringToId = (id: string): Id => {
-  const [projectId, fileName, ...rest] = id.split(
-    RegExp(`${PROJECT_ID_SEPARATOR}|${TEST_ID_SEPARATOR}|${DESCRIBE_ID_SEPARATOR}`),
-  );
+  const { projectId, fileName, rest } = id.match(
+    RegExp(`(?<projectId>[^${PROJECT_ID_SEPARATOR}]*)(${PROJECT_ID_SEPARATOR}(?<fileName>[^${DESCRIBE_ID_SEPARATOR}${TEST_ID_SEPARATOR}]*)?(?<rest>.*))?`),
+  )?.groups || {};
+
+  // TestID is everything after first TEST_ID_SEPARATOR, if we find multiple TEST_ID_SEPARATORs, add them back in
+  const [ describes, ...testIdParts ] = rest.split(TEST_ID_SEPARATOR);
+  const testId = testIdParts.join(TEST_ID_SEPARATOR);
+  // Remaining string will start with DESCRIBE_ID_SEPARATOR, so throw away first part when splitting
+  const [, ...describeIds] = describes.split(DESCRIBE_ID_SEPARATOR);
 
   return {
-    describeIds: rest.length > 1 ? rest.slice(0, rest.length - 1) : undefined,
+    describeIds: describeIds.length ? describeIds : undefined,
     fileName,
     projectId,
-    testId: rest[rest.length - 1],
+    testId
   };
 };
 

--- a/src/helpers/idMaps.ts
+++ b/src/helpers/idMaps.ts
@@ -44,4 +44,4 @@ const mapStringToId = (id: string): Id => {
   };
 };
 
-export { mapIdToString, mapStringToId };
+export { mapIdToString, mapStringToId, Id };

--- a/src/helpers/idMaps.ts
+++ b/src/helpers/idMaps.ts
@@ -31,8 +31,8 @@ const mapStringToId = (id: string): Id => {
   )?.groups || {};
 
   // TestID is everything after first TEST_ID_SEPARATOR, if we find multiple TEST_ID_SEPARATORs, add them back in
-  const [ describes, ...testIdParts ] = rest.split(TEST_ID_SEPARATOR);
-  const testId = testIdParts.join(TEST_ID_SEPARATOR);
+  const [ describes, ...testIdParts ] = (rest || '').split(TEST_ID_SEPARATOR);
+  const testId = testIdParts.join(TEST_ID_SEPARATOR) || undefined;
   // Remaining string will start with DESCRIBE_ID_SEPARATOR, so throw away first part when splitting
   const [, ...describeIds] = describes.split(DESCRIBE_ID_SEPARATOR);
 

--- a/src/helpers/mapTestIdsToTestFilter.ts
+++ b/src/helpers/mapTestIdsToTestFilter.ts
@@ -1,7 +1,15 @@
 import _ from 'lodash';
 import { ITestFilter } from "../types";
 import escapeRegExp from "./escapeRegExp";
-import { mapStringToId } from "./idMaps";
+import { mapStringToId, Id } from "./idMaps";
+
+function mapTestIdsToTestNamePattern(test: Id): string {
+  // Jest test names are a concatenation of the describeIds and testId, separated by space
+  return (test.describeIds || []).concat(test.testId || '')
+    .filter(testPart => testPart)
+    .map(part => escapeRegExp(part || ""))
+    .join(' ');
+}
 
 export function mapTestIdsToTestFilter(tests: string[]): ITestFilter | null {
   if (tests.length === 0 || tests.some(t => t === "root")) {
@@ -17,7 +25,9 @@ export function mapTestIdsToTestFilter(tests: string[]): ITestFilter | null {
 
   // we accumulate the file and test names into regex expressions.  Note we escape the names to avoid interpreting
   // any regex control characters in the file or test names.
-  const testNamePattern = ids.filter(x => x.testId).map(z => escapeRegExp(z.testId || "")).join("|");
+  const testNamePattern = ids.map(mapTestIdsToTestNamePattern)
+    .filter(testId => testId)
+    .join("|");
   const testFileNamePattern = ids.filter(x => x.fileName).map(z => escapeRegExp(z.fileName || "")).join("|");
 
   return {


### PR DESCRIPTION
Fixes #99 
Fixes #102 

When the id contained describe blocks, but no `testId` (e.g. when running a describe block), the last describe block was being treated as a `testId`.  This PR ensures that all describe blocks will be counted as `describeIds`, and only when a test separator is present will there be a `testId`.

Additionally, when running a describe block, there were two issues causing it to display results for too wide of a set of tests:
1) Tree filtering was only being done at the root describe level.  Descendent describe blocks are now filtered so that the tree is only the describe chain selected.
2) When running a describe block, Jest was being invoked with no test filter, only a file filter.  It is now invoked with a specific test filter that includes the describe block names.  If this part causes issue for some (for instance, when using template strings in their describe names), we could look at disabling this with a setting.

***Result when `processAcc` is run***
(Fixes #99 - it actually runs)
(Fixes #102 - it only runs `processAcc` and not its siblings inside `State`)
![image](https://user-images.githubusercontent.com/9260413/102998239-cd2e3a80-44f4-11eb-9513-b46a1ad76f05.png)
