### PR TITLE
Support new nx project format

### DIFF
--- a/src/repo/NxdevBase.ts
+++ b/src/repo/NxdevBase.ts
@@ -1,6 +1,6 @@
 import { JSONSchemaForNPMPackageJsonFiles } from "@schemastore/package";
 import fs from "fs";
-import _, { keyBy } from "lodash";
+import _ from "lodash";
 import path from "path";
 import { gt } from "semver";
 import util from "util";

--- a/src/repo/types.ts
+++ b/src/repo/types.ts
@@ -6,6 +6,7 @@ export interface ProjectConfig {
   jestExecutionDirectory: string;
   projectName: string;
   rootPath: string;
+  setupFile?: string;
   tsConfig?: string;
 }
 


### PR DESCRIPTION
Nx now has a [new project format](https://nx.dev/configuration/projectjson) (which is currently optional for Angular projects). If you use this format Jest Test Adapter won't be able to find the projects because the new angular.json looks like this:

```
{
   //...
   projects: {
      'my-app': 'apps/my-app'
   }
}
```

The real config lives in `apps/my-app/projects.json`. And also has a slighly changed format (`architect` -> `targets` and `builder` -> `executor`).

I've created a fix which checks if the config in `angular.json` is a string and if it is reads the config from the according `project.json` file.